### PR TITLE
fix: 프로젝트 목록 페이지 - 프론트엔드 섹션 높이값 수정

### DIFF
--- a/src/app/projects/[type]/[id]/components/frontend/components/contents/components/MeetingSection.tsx
+++ b/src/app/projects/[type]/[id]/components/frontend/components/contents/components/MeetingSection.tsx
@@ -27,7 +27,7 @@ export default function MeetingSection({
           {list && (
             <ul className={clsx("pt-2 space-y-2 pl-4")}>
               {list.map((li, idx) => (
-                <li key={idx} className="relative pl-4">
+                <li key={idx} className={clsx("relative pl-4")}>
                   <span
                     className={clsx(
                       "absolute left-0 top-2 inline-block w-1 h-1 rounded-full bg-white"

--- a/src/app/projects/components/Carousel.tsx
+++ b/src/app/projects/components/Carousel.tsx
@@ -37,7 +37,12 @@ export default function Carousel({
   const { settings } = customSettings();
 
   return filteredData.length > 0 ? (
-    <div className={clsx(filteredData.length < 3 && "leftMode")}>
+    <div
+      className={clsx(
+        filteredData.length < 3 && "leftMode",
+        type === "frontend" && "min-h-[470px]"
+      )}
+    >
       <Slider {...settings} touchMove={true} verticalSwiping={false}>
         {filteredData.map((project) => (
           <div
@@ -83,15 +88,17 @@ export default function Carousel({
                     )}
                   />
                 </div>
-                <p
-                  className={clsx(
-                    "mt-3 font-light",
-                    type === "publishing" && "hidden",
-                    type === "frontend" && "max-md:hidden"
-                  )}
-                >
-                  {project.description}
-                </p>
+                {loadedMap[project.id] && (
+                  <p
+                    className={clsx(
+                      "mt-3 font-light",
+                      type === "publishing" && "hidden",
+                      type === "frontend" && "max-md:hidden"
+                    )}
+                  >
+                    {project.description}
+                  </p>
+                )}
               </div>
               {!loadedMap[project.id] && <Skeleton />}
               <Image


### PR DESCRIPTION
## ✨ What’s Changed?

- 프로젝트 목록 페이지 - 프론트엔드 섹션 높이값이 없어 렌더링 시 섹션의 높낮이가 버벅거리는 이슈 수정
- 스켈레톤에 컨텐츠(텍스트)가 보이는 버그 수정

## 📸 Screenshots

![화면 기록 2025-08-06 오후 4 20 19](https://github.com/user-attachments/assets/bac24558-37ac-4d1e-b644-1facacb3f84f)
